### PR TITLE
Exclude migrations from coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,6 @@ omit =
 
     # testing utilities
     */testing_utils.py
+
+    # migrations
+    */migrations/*


### PR DESCRIPTION
Resolve issue where migrations were included in the coverage report (#6).
