### PR TITLE
Add 'get_absolute_url' method to Activity model.

### DIFF
--- a/timetracker/models.py
+++ b/timetracker/models.py
@@ -3,6 +3,7 @@
 These models are responsible for storing and representing the data that
 is manipulated within the app.
 """
+from django.core.urlresolvers import reverse
 
 from django.db import models
 from django.utils import timezone
@@ -29,6 +30,15 @@ class Activity(models.Model):
 
         return '{}: {} - {}'.format(
             self.title, self.start_time.strftime('%Y-%M-%d %H:%m'), end_str)
+
+    def get_absolute_url(self):
+        """Return the URL of the instance's detail view.
+
+        Returns:
+            str: The URL of the instance's detail view, in the format:
+                `/activities/<pk>/`.
+        """
+        return reverse('activity-detail', kwargs={'pk': self.pk})
 
     @property
     def is_active(self):

--- a/timetracker/tests/test_models.py
+++ b/timetracker/tests/test_models.py
@@ -1,11 +1,13 @@
 from datetime import timedelta
 
 from django.test import TestCase
+from django.core.urlresolvers import reverse
 from django.utils import timezone
 
 import mock
 
 from timetracker import models
+from timetracker.testing_utils import create_activity
 
 
 class TestActivityModel(TestCase):
@@ -45,6 +47,16 @@ class TestActivityModel(TestCase):
         self.assertEqual(1, mock_now.call_count)
         self.assertEqual(time, activity.start_time)
         self.assertIsNone(activity.end_time)
+
+    def test_get_absolute_url(self):
+        """Test getting the absolute url of an `Activity` instance.
+
+        The returned URL should be the instance's detail view.
+        """
+        activity = create_activity()
+        expected = reverse('activity-detail', kwargs={'pk': activity.pk})
+
+        self.assertEqual(expected, activity.get_absolute_url())
 
     def test_is_active(self):
         """Test the `Activity` model's `is_active` property.


### PR DESCRIPTION
This method is mostly for convenience, replacing longer calls to
'reverse'. It is also used by Django's admin to display the "Show on
Site" button.

Closes #7
