### PR TITLE
Add tox configuration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ coverage
 django-nose
 flake8
 mock
+tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,10 @@ exclude =
     env/,
 
     # migrations
-    */migrations/*
+    */migrations/*,
+
+    # exclude tox so flake8 doesn't explode
+    .tox/
 
 [nosetests]
 cover-package = timetracker

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = {py27,py34,py35}--django{18,19,110}, py33--django18, lint
+
+[testenv]
+deps =
+    django18: django >= 1.8 , <1.9
+    django19: django >= 1.9 , <1.10
+    django110: django >= 1.10, < 1.11
+    coverage
+    django-nose
+    mock
+commands =
+    ./manage.py test
+
+[testenv:lint]
+deps = flake8
+commands = flake8 .


### PR DESCRIPTION
The tox configuration mirrors the tests run by travis-ci so that tests can be done locally.

Closes #13.
